### PR TITLE
chore: update catalog version to align with skypilot 0.11.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Configuration is managed via environment variables with the prefix `EXLS_SKY_`.
 | --------------------------- | ----------------------------- | --------- | --------------------------------------------------------------------- |
 | `EXLS_SKY_API_HOST`         | `0.0.0.0` (string)            | No        | Host to run the API on. Defaults to `0.0.0.0`.                        |
 | `EXLS_SKY_API_PORT`         | `5555` (integer)              | No        | Port to run the API on. Defaults to `5555`.                           |
-| `EXLS_SKY_CATALOG_PATH`     | `~/.sky/catalogs/v7` (string) | No        | Path to the catalog root directory. Defaults to `~/.sky/catalogs/v7`. |
+| `EXLS_SKY_CATALOG_PATH`     | `~/.sky/catalogs/v8` (string) | No        | Path to the catalog root directory. Defaults to `~/.sky/catalogs/v8`. |
 | `EXLS_SKY_CATALOG_FILENAME` | `vms.csv` (string)            | No        | Name of the catalog file. Defaults to `vms.csv`.                      |
 
 ## API
@@ -137,7 +137,7 @@ A multi-stage `Dockerfile` is provided for building a minimal production image.
 
     ```sh
     docker run -d -p 8000:5555 \
-      -v ~/.sky/catalogs/v7:/root/.sky/catalogs/v7 \
+      -v ~/.sky/catalogs/v8:/root/.sky/catalogs/v8 \
       --name skypilot-sidecar-app \
       skypilot-sidecar
     ```

--- a/src/config.py
+++ b/src/config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-DEFAULT_SKY_CATALOG_PATH: Path = Path.home() / ".sky" / "catalogs" / "v7"
+DEFAULT_SKY_CATALOG_PATH: Path = Path.home() / ".sky" / "catalogs" / "v8"
 
 
 class AppConfig(BaseSettings):

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -200,7 +200,7 @@ class TestDefaultSkyPath:
 
     def test_default_sky_catalog_path(self):
         """Test that DEFAULT_SKY_CATALOG_PATH is correctly constructed."""
-        expected_path = Path.home() / ".sky" / "catalogs" / "v7"
+        expected_path = Path.home() / ".sky" / "catalogs" / "v8"
         assert DEFAULT_SKY_CATALOG_PATH == expected_path
 
     def test_default_sky_catalog_path_type(self):


### PR DESCRIPTION
We updated skypilot to 0.11.2 and it now focuses on catalog v8, hence we update as well.